### PR TITLE
Added asset-share-commons.base as dependency

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/sample-assetshare/clientlibs/clientlib-theme/semanticui-sample/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/sample-assetshare/clientlibs/clientlib-theme/semanticui-sample/.content.xml
@@ -3,5 +3,6 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[asset-share-commons.semantic-ui-sample]"
-    embed="[             asset-share-commons.semantic-ui-sample.globals,             asset-share-commons.semantic-ui-sample.elements,             asset-share-commons.semantic-ui-sample.collections,             asset-share-commons.semantic-ui-sample.views,             asset-share-commons.semantic-ui-sample.modules,asset-share-commons.site.semantic-ui,             asset-share-commons.site.semantic-ui.components             ]"
+    dependencies="[asset-share-commons.base]"      
+    embed="[asset-share-commons.semantic-ui-sample.globals,asset-share-commons.semantic-ui-sample.elements,asset-share-commons.semantic-ui-sample.collections,             asset-share-commons.semantic-ui-sample.views,asset-share-commons.semantic-ui-sample.modules,asset-share-commons.site.semantic-ui,asset-share-commons.site.semantic-ui.components]"
     jsProcessor="[min:gcc,default:none]"/>


### PR DESCRIPTION
The semantic themes should list "asset-share-commons.base" to avoid double JS inclusion.